### PR TITLE
ios和mac下safari内核web端播放无法开始的现象修复

### DIFF
--- a/backend/src/api/handlers/media.rs
+++ b/backend/src/api/handlers/media.rs
@@ -28,6 +28,26 @@ pub struct StreamQuery {
     pub seek: Option<String>,
 }
 
+fn stream_mime_type_from_path(path: &str) -> String {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    match ext.as_str() {
+        // WebKit prefers audio/mp4 for m4a/mp4 audio streams.
+        "m4a" | "mp4" => "audio/mp4".to_string(),
+        "mp3" => "audio/mpeg".to_string(),
+        "aac" => "audio/aac".to_string(),
+        "flac" => "audio/flac".to_string(),
+        "ogg" => "audio/ogg".to_string(),
+        "opus" => "audio/opus".to_string(),
+        "wav" => "audio/wav".to_string(),
+        _ => mime_guess::from_path(path).first_or_octet_stream().to_string(),
+    }
+}
+
 /// Handler for POST /api/cache/:chapterId - Cache a chapter
 pub async fn cache_chapter(
     State(state): State<AppState>,
@@ -710,7 +730,7 @@ pub async fn stream_chapter(
                 drop(cache);
                 
                 let file_size = data.len() as u64;
-                let mime_type = mime_guess::from_path(&chapter.path).first_or_octet_stream().to_string();
+                let mime_type = stream_mime_type_from_path(&chapter.path);
                 
                 let range_header = headers.get(header::RANGE).and_then(|v| v.to_str().ok());
                 
@@ -769,7 +789,7 @@ pub async fn stream_chapter(
                 // This is handled by the `if cache_path.exists()` checks in the plugin block
             } else {
                 let file_size = tokio::fs::metadata(&cache_path).await?.len();
-                let mime_type = mime_guess::from_path(&chapter.path).first_or_octet_stream().to_string();
+                let mime_type = stream_mime_type_from_path(&chapter.path);
                 
                 let range_header = headers.get(header::RANGE).and_then(|v| v.to_str().ok());
                 if let Some(range_str) = range_header {
@@ -907,7 +927,7 @@ pub async fn stream_chapter(
     let stream = ReaderStream::new(reader);
     let body = Body::from_stream(stream);
 
-    let mime_type = mime_guess::from_path(&chapter.path).first_or_octet_stream().to_string();
+    let mime_type = stream_mime_type_from_path(&chapter.path);
 
     if range_header.is_some() {
         let content_range = format!("bytes {}-{}/{}", start, end.saturating_sub(1), total_size);

--- a/frontend/src/components/Player.tsx
+++ b/frontend/src/components/Player.tsx
@@ -312,6 +312,14 @@ const Player: React.FC = () => {
   const isInitialLoadRef = useRef(true);
   const preloadAudioRef = useRef<HTMLAudioElement | null>(null);
 
+  const tryTranscodeFallback = () => {
+    if (shouldTranscode || retryCount >= 3) return;
+    setError('检测到浏览器兼容性问题，正在切换兼容音频流...');
+    setShouldTranscode(true);
+    setRetryCount(prev => prev + 1);
+    isInitialLoadRef.current = true;
+  };
+
   // Fetch settings for auto_preload and user preferences
   useEffect(() => {
     apiClient.get('/api/settings').then(res => {
@@ -430,6 +438,35 @@ const Player: React.FC = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPlaying, currentChapter?.id, retryCount, shouldTranscode]);
+
+  // Some browsers may report "playing" while decode hasn't actually advanced.
+  // Detect "stuck at start" by checking that currentTime does not move after a delay,
+  // while enough data is already buffered and media is in a playable readyState.
+  useEffect(() => {
+    if (!isPlaying || !currentChapter || !audioRef.current) return;
+
+    const initialTime = audioRef.current.currentTime || 0;
+    const timer = setTimeout(() => {
+      const audio = audioRef.current;
+      if (!audio || audio.paused || audio.seeking || audio.ended) return;
+      if (audio.error) return;
+
+      const time = audio.currentTime || 0;
+      const progressed = time - initialTime;
+      let bufferedEnd = 0;
+      if (audio.buffered.length > 0) {
+        bufferedEnd = audio.buffered.end(audio.buffered.length - 1);
+      }
+
+      const readyForDecode = audio.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA;
+      const decodeStuck = time < 0.05 && progressed < 0.03 && bufferedEnd > 1.5 && readyForDecode;
+      if (decodeStuck) {
+        tryTranscodeFallback();
+      }
+    }, 4500);
+
+    return () => clearTimeout(timer);
+  }, [isPlaying, currentChapter?.id, shouldTranscode, retryCount]);
 
   // Preload and Server-side Cache next chapter logic
   useEffect(() => {
@@ -876,9 +913,7 @@ const Player: React.FC = () => {
             // Auto retry on network (2), decode error (3) or source not supported (4)
             // We include network error (2) in retry logic just in case, but transcode mainly fixes 3 & 4
             if (retryCount < 3) {
-                 console.log(`Playback error ${audio.error.code}, 使用转码重试 (${retryCount + 1}/3)...`);
-                 setShouldTranscode(true);
-                 setRetryCount(prev => prev + 1);
+                 tryTranscodeFallback();
                  return;
             }
             console.error('音频元素错误', audio.error);
@@ -886,9 +921,7 @@ const Player: React.FC = () => {
             // Even if audio.error is null, if we have an error event and haven't retried max times, try transcoding
             // This handles edge cases where browser doesn't populate error object properly
             if (retryCount < 3) {
-                console.log('未知的音频错误，尝试转码重试...');
-                setShouldTranscode(true);
-                setRetryCount(prev => prev + 1);
+                tryTranscodeFallback();
                 return;
             }
             console.error('音频元素错误 (未知)', e);

--- a/frontend/src/components/Player.tsx
+++ b/frontend/src/components/Player.tsx
@@ -413,6 +413,13 @@ const Player: React.FC = () => {
             console.log('播放承诺已中止 (正常)');
             return;
           }
+          if (err.name === 'NotAllowedError') {
+            // Safari/iOS may reject play() when it isn't treated as a direct user gesture.
+            setIsPlaying(false);
+            setError('浏览器阻止了自动播放，请再次点击播放按钮');
+            console.warn('播放被浏览器策略阻止', err);
+            return;
+          }
           console.error('播放失败', err);
           // Don't set user-visible error yet, let onError handler try to recover first
           // setError('播放失败，可能是文件格式不支持或网络错误');
@@ -832,12 +839,15 @@ const Player: React.FC = () => {
         ref={audioRef}
         src={getStreamUrl(currentChapter.id)}
         crossOrigin="anonymous"
+        playsInline
+        preload="metadata"
         onTimeUpdate={handleTimeUpdate}
         onProgress={handleProgress}
         onLoadedMetadata={handleLoadedMetadata}
         onEnded={handleEnded}
         onPlay={() => {
           setIsPlaying(true);
+          setError(null);
           if (audioRef.current) {
             audioRef.current.playbackRate = playbackSpeed;
           }


### PR DESCRIPTION
ios下safari内核浏览器端(safari/chrome)点击开始播放后,播放没有开始,播放按钮表现出播放状态却没有实际开始播放,进度持续在00:00位置不推进的卡住现象,观察到页面进度条有缓冲

问题出现平台: ios18.7 safari/chrome, Mac safari 
以下平台未发现该现象: chrome on Mac / chrome on linux_x64